### PR TITLE
create_function() has been DEPRECATED as of PHP 7.2.0

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -104,12 +104,14 @@ class WeDevs_Settings_API {
             }
 
             if ( isset($section['desc']) && !empty($section['desc']) ) {
-                $section['desc'] = '<div class="inside">' . $section['desc'] . '</div>';
-                $callback = create_function('', 'echo "' . str_replace( '"', '\"', $section['desc'] ) . '";');
+                $desc = '<div class="inside">' . $section['desc'] . '</div>';
+                $callback = function () use ($desc) {
+                    echo $desc;
+                };
             } else if ( isset( $section['callback'] ) ) {
                 $callback = $section['callback'];
             } else {
-                $callback = null;
+                $callback = false;
             }
 
             add_settings_section( $section['id'], $section['title'], $callback, $section['id'] );


### PR DESCRIPTION
Relying on this function is highly discouraged. [Manual](http://php.net/manual/en/function.create-function.php). Thus creating an anonymous function with closure is better, so as to make use of the parent scope.
Also, the section callback is [checked for boolean](https://core.trac.wordpress.org/browser/tags/4.7/src/wp-admin/includes/template.php#L1296). So, it's better to set it `false` than `null`.